### PR TITLE
Typing hints specifying units cause `TypeError` for Python < 3.9

### DIFF
--- a/VSPEC/geometry.py
+++ b/VSPEC/geometry.py
@@ -333,7 +333,7 @@ class SystemGeometry:
         time = newton(func, (guess/u.day).to(u.Unit(''))) * u.day
         return time.to(u.day)
 
-    def get_substellar_lon_at_periasteron(self) -> u.Quantity[u.deg]:
+    def get_substellar_lon_at_periasteron(self) -> u.Quantity:
         """
         Compute the sub-stellar longitude at the previous periasteron
         given the rotation period, orbital period, and initial
@@ -382,7 +382,7 @@ class SystemGeometry:
         # lon = self.planetary_init_substellar_lon + dphase - rotated
         return lon % (360.0*u.deg)
 
-    def get_substellar_lat(self, phase: u.Quantity[u.deg]) -> u.Quantity[u.deg]:
+    def get_substellar_lat(self, phase: u.Quantity) -> u.Quantity:
         """
         Calculate the sub-stellar latitude of the planet at a particular phase.
 
@@ -428,7 +428,7 @@ class SystemGeometry:
         lon = self.get_substellar_lon(time_since_periasteron) - phase
         return lon
 
-    def get_pl_sub_obs_lat(self, phase: u.Quantity[u.deg]) -> u.Quantity[u.deg]:
+    def get_pl_sub_obs_lat(self, phase: u.Quantity) -> u.Quantity:
         """
         Compute the sub-observer latitude of the planet.
 

--- a/VSPEC/helpers/misc.py
+++ b/VSPEC/helpers/misc.py
@@ -9,11 +9,11 @@ import pandas as pd
 
 
 def get_transit_radius(
-    system_distance: u.Quantity[u.pc],
-    stellar_radius: u.Quantity[u.R_sun],
-    semimajor_axis: u.Quantity[u.AU],
-    planet_radius: u.Quantity[u.R_earth]
-) -> u.Quantity[u.rad]:
+    system_distance: u.Quantity,
+    stellar_radius: u.Quantity,
+    semimajor_axis: u.Quantity,
+    planet_radius: u.Quantity
+) -> u.Quantity:
     """
     Get the phase radius of a planetary transit.
 
@@ -57,7 +57,10 @@ def get_transit_radius(
     return (angle_point_planet+planet_radius_angle)*u.rad
 
 
-def get_planet_indicies(planet_times: u.Quantity, tindex: u.Quantity) -> tuple[int, int]:
+def get_planet_indicies(
+    planet_times: u.Quantity,
+    tindex: u.Quantity
+    ) -> tuple[int, int]:
     """
     Get the indices of the planet spectra to interpolate over.
 

--- a/VSPEC/main.py
+++ b/VSPEC/main.py
@@ -540,7 +540,7 @@ class ObservationModel:
             seed=self.params.header.seed
         )
 
-    def warm_up_star(self, spot_warmup_time: u.Quantity[u.day] = 0*u.day, facula_warmup_time: u.Quantity[u.day] = 0*u.day):
+    def warm_up_star(self, spot_warmup_time: u.Quantity = 0*u.day, facula_warmup_time: u.Quantity = 0*u.day):
         """
         "Warm up" the star. Generate spots, faculae, and/or flares for the star.
         The goal is to approach growth-decay equillibrium, something that is hard to

--- a/VSPEC/variable_star_model/faculae.py
+++ b/VSPEC/variable_star_model/faculae.py
@@ -195,7 +195,7 @@ class Facula:
         msg = 'The `set_gridmaker` method of Facula is no longer necessary.'
         warnings.warn(msg, DeprecationWarning)
 
-    def age(self, time: Quantity[u.day]):
+    def age(self, time: Quantity):
         """
         Progress the development of the facula by an amount of time.
 
@@ -303,8 +303,8 @@ class Facula:
                 round_teff(self.floor_dteff): np.trapz(Reffs, x)
             }
 
-    def fractional_effective_area(self, angle: Quantity[u.deg],
-                                  N: int = 101) -> Dict[Quantity[u.K], Quantity]:
+    def fractional_effective_area(self, angle: Quantity,
+                                  N: int = 101) -> Dict[Quantity, Quantity]:
         """
         Calculate the fractional effective area as a fraction of the
         projected area of a region of quiet photosphere with

--- a/VSPEC/variable_star_model/flares.py
+++ b/VSPEC/variable_star_model/flares.py
@@ -69,7 +69,7 @@ class StellarFlare:
         self.Teff = Teff
         self.tpeak = tpeak
 
-    def calc_peak_area(self) -> u.Quantity[u.km**2]:
+    def calc_peak_area(self) -> u.Quantity:
         """
         Calculate the flare area at its peak
 
@@ -84,7 +84,7 @@ class StellarFlare:
         area = time_area/time_area_std * area_std
         return area.to(u.km**2)
 
-    def areacurve(self, time: Quantity[u.hr]):
+    def areacurve(self, time: Quantity):
         """
         Compute the flare area as a function of time
 
@@ -110,7 +110,7 @@ class StellarFlare:
         )
         return areas * a_unit
 
-    def get_timearea(self, time: Quantity[u.hr]):
+    def get_timearea(self, time: Quantity):
         """
         Calcualte the integrated time*area of the flare.
 
@@ -557,7 +557,7 @@ class FlareCollection:
         self.peaks = tpeak
         self.fwhms = fwhm
 
-    def mask(self, tstart: Quantity[u.hr], tfinish: Quantity[u.hr]):
+    def mask(self, tstart: Quantity, tfinish: Quantity):
         """
         Create a boolean mask to indicate which flares are visible within a certain time period.
 
@@ -581,7 +581,7 @@ class FlareCollection:
 
         return after_start & before_end
 
-    def get_flares_in_timeperiod(self, tstart: Quantity[u.hr], tfinish: Quantity[u.hr]) -> List[StellarFlare]:
+    def get_flares_in_timeperiod(self, tstart: Quantity, tfinish: Quantity) -> List[StellarFlare]:
         """
         Generate a mask and select flares without casting to `np.ndarray`
         (use a list comprehension instead).
@@ -605,7 +605,7 @@ class FlareCollection:
         # essentially the same as self.flares[mask], but without casting to ndarray
         return masked_flares
 
-    def get_visible_flares_in_timeperiod(self, tstart: Quantity[u.hr], tfinish: Quantity[u.hr],
+    def get_visible_flares_in_timeperiod(self, tstart: Quantity, tfinish: Quantity,
                                          sub_obs_coords={'lat': 0*u.deg, 'lon': 0*u.deg}) -> List[StellarFlare]:
         """
         Get visible flares in a given time period on a given hemisphere.
@@ -635,7 +635,7 @@ class FlareCollection:
                 visible_flares.append(flare)
         return visible_flares
 
-    def get_flare_integral_in_timeperiod(self, tstart: Quantity[u.hr], tfinish: Quantity[u.hr],
+    def get_flare_integral_in_timeperiod(self, tstart: Quantity, tfinish: Quantity,
                                          sub_obs_coords={'lat': 0*u.deg, 'lon': 0*u.deg}):
         """
         Calculate the integrated time-area for each visible

--- a/VSPEC/variable_star_model/spots.py
+++ b/VSPEC/variable_star_model/spots.py
@@ -104,9 +104,9 @@ class StarSpot:
     """
 
     def __init__(
-        self, lat: Quantity[u.deg], lon: Quantity[u.deg], Amax: Quantity[MSH], A0: Quantity[MSH],
-        Teff_umbra: Quantity[u.K], Teff_penumbra: Quantity[u.K], r_A: float = 5, growing: bool = True,
-        growth_rate: Quantity[1/u.day] = 0.52/u.day, decay_rate: Quantity[MSH/u.day] = 10.89 * MSH/u.day,
+        self, lat: Quantity, lon: Quantity, Amax: Quantity, A0: Quantity,
+        Teff_umbra: Quantity, Teff_penumbra: Quantity, r_A: float = 5, growing: bool = True,
+        growth_rate: Quantity = 0.52/u.day, decay_rate: Quantity = 10.89 * MSH/u.day,
         Nlat: int = 500, Nlon: int = 1000, gridmaker=None
     ):
 
@@ -149,7 +149,7 @@ class StarSpot:
         return s
 
     @property
-    def radius(self) -> Quantity[u.km]:
+    def radius(self) -> Quantity:
         """
         Radius
 
@@ -162,7 +162,7 @@ class StarSpot:
         """
         return np.sqrt(self.area_current/np.pi).to(u.km)
 
-    def angular_radius(self, star_rad: Quantity[u.R_sun]) -> Quantity[u.deg]:
+    def angular_radius(self, star_rad: Quantity) -> Quantity:
         """
         Angular radius
 
@@ -181,7 +181,7 @@ class StarSpot:
         cos_angle = 1 - self.area_current/(2*np.pi*star_rad**2)
         return (np.arccos(cos_angle)).to(u.deg)
 
-    def map_pixels(self, star_rad: Quantity[u.R_sun]) -> dict:
+    def map_pixels(self, star_rad: Quantity) -> dict:
         """
         Map latitude and longituide points continaing the umbra and penumbra
 
@@ -210,7 +210,7 @@ class StarSpot:
                 self.Teff_penumbra: self.r < radius}
 
     def surface_fraction(self, sub_obs_coords: dict,
-                         star_rad: Quantity[u.R_sun], N: int = 1001) -> float:
+                         star_rad: Quantity, N: int = 1001) -> float:
         """
         Determine the surface fraction covered by a spot from a given 
         angle of observation using the orthographic projection.
@@ -245,7 +245,7 @@ class StarSpot:
         integrand = 2 * np.cos(c)*np.sqrt(rad)
         return (np.trapz(integrand, x=c)/(2*np.pi*u.steradian)).to_value(u.dimensionless_unscaled)
 
-    def age(self, time: Quantity[u.s]) -> None:
+    def age(self, time: Quantity) -> None:
         """
         Age a spot according to its growth timescale and decay rate
 
@@ -393,7 +393,7 @@ class SpotCollection:
                 spots_to_keep.append(spot)
         self.spots = spots_to_keep
 
-    def map_pixels(self, star_rad: Quantity[u.R_sun], star_teff: Quantity[u.K]):
+    def map_pixels(self, star_rad: Quantity, star_teff: Quantity):
         """
         Map latitude and longitude points containing the umbra and penumbra
         of each spot. For pixels with coverage from multiple spots, assign
@@ -428,7 +428,7 @@ class SpotCollection:
                 penumbra, spot.Teff_penumbra, surface_map))
         return surface_map
 
-    def age(self, time: Quantity[u.day]) -> None:
+    def age(self, time: Quantity) -> None:
         """
         Age spots according to its growth timescale and decay rate.
 
@@ -547,13 +547,13 @@ class SpotGenerator:
     """
 
     def __init__(self,
-                 dist_area_mean: Quantity[MSH],
+                 dist_area_mean: Quantity,
                  dist_area_logsigma: float,
-                 umbra_teff: Quantity[u.K],
-                 penumbra_teff: Quantity[u.K],
-                 growth_rate: Quantity[1/u.day] = 0.52/u.day,
-                 decay_rate: Quantity[MSH/u.day] = 10.89 * MSH/u.day,
-                 init_area: Quantity[MSH] = 10*MSH,
+                 umbra_teff: Quantity,
+                 penumbra_teff: Quantity,
+                 growth_rate: Quantity = 0.52/u.day,
+                 decay_rate: Quantity = 10.89 * MSH/u.day,
+                 init_area: Quantity = 10*MSH,
                  distribution='solar',
                  coverage: float = 0.2,
                  Nlat: int = 500,
@@ -741,7 +741,7 @@ class SpotGenerator:
             ))
         return tuple(spots)
 
-    def get_N_spots_to_birth(self, time: Quantity[u.day], rad_star: Quantity[u.R_sun]) -> float:
+    def get_N_spots_to_birth(self, time: Quantity, rad_star: Quantity) -> float:
         """
         Calculate how many new `StarSpot` objects to birth over a given time duration (expectation value).
 
@@ -762,7 +762,7 @@ class SpotGenerator:
                  time / self.mean_lifetime).to_value(u.dimensionless_unscaled)
         return N_exp
 
-    def birth_spots(self, time: Quantity[u.day], rad_star: Quantity[u.R_sun]) -> tuple[StarSpot]:
+    def birth_spots(self, time: Quantity, rad_star: Quantity) -> tuple[StarSpot]:
         """
         Generate new `StarSpot` objects to be birthed over a given time duration.
 
@@ -786,7 +786,7 @@ class SpotGenerator:
 
         return self.generate_spots(N)
 
-    def generate_mature_spots(self, coverage: float, R_star: Quantity[u.R_sun]) -> List[StarSpot]:
+    def generate_mature_spots(self, coverage: float, R_star: Quantity) -> List[StarSpot]:
         """Generate mature StarSpot objects to cover a given fraction of the star's surface.
 
         This method generates mature spots such that the total solid angle subtended by the spots

--- a/VSPEC/variable_star_model/star.py
+++ b/VSPEC/variable_star_model/star.py
@@ -664,7 +664,7 @@ class Star:
         ax.imshow(np.ones_like(ld), extent=(lon.min(), lon.max(), lat.min(), lat.max()),
                   transform=ccrs.PlateCarree(), origin='lower', alpha=alpha, cmap=plt.cm.get_cmap('gray'), zorder=100)
 
-    def get_flares_over_observation(self, time_duration: Quantity[u.hr]):
+    def get_flares_over_observation(self, time_duration: Quantity):
         """
         Generate a collection of flares over a specified observation period.
 
@@ -683,7 +683,7 @@ class Star:
         flares = self.flare_generator.generate_flare_series(time_duration)
         self.flares = FlareCollection(flares)
 
-    def get_flare_int_over_timeperiod(self, tstart: Quantity[u.hr], tfinish: Quantity[u.hr], sub_obs_coords):
+    def get_flare_int_over_timeperiod(self, tstart: Quantity, tfinish: Quantity, sub_obs_coords):
         """
         Compute the total flare integral over a specified time period and sub-observer point.
 


### PR DESCRIPTION
Fixes #12